### PR TITLE
Ai tutor jitpack

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,5 +63,9 @@ dependencies {
     implementation("io.github.rosemoe:language-textmate")
 
     // Catrobat AI Tutor
-    implementation("org.catrobat:aitutor:0.0.1")
+    implementation("com.github.Catrobat:catrobat-ai-tutor:develop-SNAPSHOT") {
+        // Choose one of the following to exclude either debug or release variant
+//        exclude(group = "com.github.Catrobat.catrobat-ai-tutor", module = "aitutor-android-debug")
+        exclude(group = "com.github.Catrobat.catrobat-ai-tutor", module = "aitutor-android")
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
         maven { url = uri("https://jitpack.io") }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        mavenLocal()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
This pull request updates the integration of the Catrobat AI Tutor library in the Android project by switching to a SNAPSHOT version from JitPack and adjusting repository sources. The changes ensure the project uses the latest AI Tutor code from the develop branch and resolves dependencies from JitPack instead of the local Maven repository.

Dependency updates and configuration:

* Switched the `org.catrobat:aitutor:0.0.1` dependency to `com.github.Catrobat:catrobat-ai-tutor:develop-SNAPSHOT` in `app/build.gradle.kts`, and excluded the `aitutor-android` module to avoid conflicts.
* Replaced `mavenLocal()` with the JitPack repository (`https://jitpack.io`) in `settings.gradle.kts` to fetch dependencies directly from GitHub.